### PR TITLE
Self select with proxy submit

### DIFF
--- a/src/base/io/log/Tags.cpp
+++ b/src/base/io/log/Tags.cpp
@@ -36,6 +36,12 @@ const char *xmrig::Tags::network()
     return tag;
 }
 
+const char* xmrig::Tags::proxy()
+{
+    static const char* tag = YELLOW_BG_BOLD(WHITE_BOLD_S " proxy   ");
+
+    return tag;
+}
 
 const char *xmrig::Tags::signal()
 {

--- a/src/base/io/log/Tags.h
+++ b/src/base/io/log/Tags.h
@@ -31,7 +31,8 @@ class Tags
 {
 public:
     static const char *config();
-    static const char *network();
+    static const char* network();
+    static const char* proxy();
     static const char *signal();
 
 #   ifdef XMRIG_MINER_PROJECT

--- a/src/base/kernel/config/BaseTransform.cpp
+++ b/src/base/kernel/config/BaseTransform.cpp
@@ -260,6 +260,7 @@ void xmrig::BaseTransform::transform(rapidjson::Document &doc, int key, const ch
     case IConfig::DryRunKey:      /* --dry-run */
     case IConfig::HttpEnabledKey: /* --http-enabled */
     case IConfig::DaemonKey:      /* --daemon */
+    case IConfig::SubmitToOriginKey: /* --submit-to-origin */
     case IConfig::VerboseKey:     /* --verbose */
     case IConfig::PauseOnBatteryKey: /* --pause-on-battery */
         return transformBoolean(doc, key, true);
@@ -289,6 +290,9 @@ void xmrig::BaseTransform::transformBoolean(rapidjson::Document &doc, int key, b
 
     case IConfig::TlsKey: /* --tls */
         return add(doc, Pools::kPools, Pool::kTls, enable);
+
+    case IConfig::SubmitToOriginKey: /* --submit-to-origin */
+        return add(doc, Pools::kPools, Pool::kSubmitToOrigin, enable);
 
 #   ifdef XMRIG_FEATURE_HTTP
     case IConfig::DaemonKey: /* --daemon */

--- a/src/base/kernel/interfaces/IConfig.h
+++ b/src/base/kernel/interfaces/IConfig.h
@@ -73,6 +73,7 @@ public:
         DaemonKey            = 1018,
         DaemonPollKey        = 1019,
         SelfSelectKey        = 1028,
+        SubmitToOriginKey    = 1049,
         DataDirKey           = 1035,
         TitleKey             = 1037,
         NoTitleKey           = 1038,

--- a/src/base/net/stratum/Client.h
+++ b/src/base/net/stratum/Client.h
@@ -62,7 +62,6 @@ public:
     constexpr static uint64_t kConnectTimeout   = 20 * 1000;
     constexpr static uint64_t kResponseTimeout  = 20 * 1000;
     constexpr static size_t kMaxSendBufferSize  = 1024 * 16;
-
     Client(int id, const char *agent, IClientListener *listener);
     ~Client() override;
 

--- a/src/base/net/stratum/Pool.h
+++ b/src/base/net/stratum/Pool.h
@@ -72,6 +72,7 @@ public:
     static const char *kPass;
     static const char *kRigId;
     static const char *kSelfSelect;
+    static const char* kSubmitToOrigin;
     static const char *kSOCKS5;
     static const char *kTls;
     static const char *kUrl;
@@ -156,6 +157,7 @@ private:
     uint64_t m_pollInterval         = kDefaultPollInterval;
     Url m_daemon;
     Url m_url;
+    bool m_submit_to_origin         = false;
 
 #   ifdef XMRIG_FEATURE_BENCHMARK
     std::shared_ptr<BenchConfig> m_benchmark;

--- a/src/base/net/stratum/SelfSelectClient.cpp
+++ b/src/base/net/stratum/SelfSelectClient.cpp
@@ -56,8 +56,8 @@ static const char * const required_fields[] = { kBlocktemplateBlob, kBlockhashin
 } /* namespace xmrig */
 
 
-xmrig::SelfSelectClient::SelfSelectClient(int id, const char *agent, IClientListener *listener) :
-    m_listener(listener)
+xmrig::SelfSelectClient::SelfSelectClient(int id, const char *agent, IClientListener *listener, bool submit_to_origin) :
+    m_listener(listener), m_submit_to_origin(submit_to_origin)
 {
     m_httpListener  = std::make_shared<HttpListener>(this);
     m_client = new Client(id, agent, this);
@@ -95,7 +95,6 @@ void xmrig::SelfSelectClient::onJobReceived(IClient *, const Job &job, const rap
 void xmrig::SelfSelectClient::onLogin(IClient *, rapidjson::Document &doc, rapidjson::Value &params)
 {
     params.AddMember("mode", "self-select", doc.GetAllocator());
-
     m_listener->onLogin(this, doc, params);
 }
 
@@ -241,7 +240,9 @@ void xmrig::SelfSelectClient::submitBlockTemplate(rapidjson::Value &result)
 
 int64_t xmrig::SelfSelectClient::submit(const JobResult& result)
 {
-    this->submit_origin_daemon(result);
+    if (m_submit_to_origin) {
+        this->submit_origin_daemon(result);
+    }
     return m_client->submit(result);
 }
 

--- a/src/base/net/stratum/SelfSelectClient.cpp
+++ b/src/base/net/stratum/SelfSelectClient.cpp
@@ -31,9 +31,11 @@
 #include "base/io/json/Json.h"
 #include "base/io/json/JsonRequest.h"
 #include "base/io/log/Log.h"
+#include "base/io/log/Tags.h"
 #include "base/net/http/Fetch.h"
 #include "base/net/http/HttpData.h"
 #include "base/net/stratum/Client.h"
+#include "net/JobResult.h"
 
 
 namespace xmrig {
@@ -58,7 +60,7 @@ xmrig::SelfSelectClient::SelfSelectClient(int id, const char *agent, IClientList
     m_listener(listener)
 {
     m_httpListener  = std::make_shared<HttpListener>(this);
-    m_client        = new Client(id, agent, this);
+    m_client = new Client(id, agent, this);
 }
 
 
@@ -201,6 +203,8 @@ void xmrig::SelfSelectClient::submitBlockTemplate(rapidjson::Value &result)
     Document doc(kObjectType);
     auto &allocator = doc.GetAllocator();
 
+    m_blocktemplate = Json::getString(result,kBlocktemplateBlob);
+
     Value params(kObjectType);
     params.AddMember(StringRef(kId),            m_job.clientId().toJSON(), allocator);
     params.AddMember(StringRef(kJobId),         m_job.id().toJSON(), allocator);
@@ -235,6 +239,33 @@ void xmrig::SelfSelectClient::submitBlockTemplate(rapidjson::Value &result)
     });
 }
 
+int64_t xmrig::SelfSelectClient::submit(const JobResult& result)
+{
+    this->submit_origin_daemon(result);
+    return m_client->submit(result);
+}
+
+void xmrig::SelfSelectClient::submit_origin_daemon(const JobResult& result)
+{
+    LOG_INFO("%s" GREEN_BOLD(" SelfSelectClient") BLACK_BOLD(" Submitting to origin"), Tags::proxy());
+
+    if (result.diff == 0) {
+        return;
+    }
+    char *data = m_blocktemplate.data();
+
+    Buffer::toHex(reinterpret_cast<const uint8_t *>(&result.nonce), 4, data + 78);
+
+    using namespace rapidjson;
+    Document doc(kObjectType);
+    Value params(kArrayType);
+    params.PushBack(m_blocktemplate.toJSON(), doc.GetAllocator());
+
+    JsonRequest::create(doc, m_sequence, "submitblock", params);
+
+    FetchRequest req(HTTP_POST, pool().daemon().host(), pool().daemon().port(), "/json_rpc", doc, pool().daemon().isTLS(), isQuiet());
+    fetch(std::move(req), m_httpListener);
+}
 
 void xmrig::SelfSelectClient::onHttpData(const HttpData &data)
 {

--- a/src/base/net/stratum/SelfSelectClient.h
+++ b/src/base/net/stratum/SelfSelectClient.h
@@ -45,7 +45,7 @@ class SelfSelectClient : public IClient, public IClientListener, public IHttpLis
 public:
     XMRIG_DISABLE_COPY_MOVE_DEFAULT(SelfSelectClient)
 
-    SelfSelectClient(int id, const char *agent, IClientListener *listener);
+    SelfSelectClient(int id, const char *agent, IClientListener *listener, bool submit_to_origin);
     ~SelfSelectClient() override;
 
 protected:
@@ -116,6 +116,7 @@ private:
     Job m_job;
     String m_blocktemplate;
     State m_state           = IdleState;
+    bool m_submit_to_origin = false;
     std::shared_ptr<IHttpListener> m_httpListener;
     uint64_t m_retryPause   = 5000;
     uint64_t m_timestamp    = 0;

--- a/src/base/net/stratum/SelfSelectClient.h
+++ b/src/base/net/stratum/SelfSelectClient.h
@@ -65,7 +65,7 @@ protected:
     inline int64_t send(const rapidjson::Value &obj, Callback callback) override    { return m_client->send(obj, callback); }
     inline int64_t send(const rapidjson::Value &obj) override                       { return m_client->send(obj); }
     inline int64_t sequence() const override                                        { return m_client->sequence(); }
-    inline int64_t submit(const JobResult &result) override                         { return m_client->submit(result); }
+    inline int64_t submit(const JobResult& result) override;
     inline void connect() override                                                  { m_client->connect(); }
     inline void connect(const Pool &pool) override                                  { m_client->connect(pool); }
     inline void deleteLater() override                                              { m_client->deleteLater(); }
@@ -105,15 +105,16 @@ private:
     void retry();
     void setState(State state);
     void submitBlockTemplate(rapidjson::Value &result);
-
+    inline void submit_origin_daemon(const JobResult &result);
     bool m_active           = false;
     bool m_quiet            = false;
-    IClient *m_client;
+    IClient* m_client;
     IClientListener *m_listener;
     int m_retries           = 5;
     int64_t m_failures      = 0;
     int64_t m_sequence      = 1;
     Job m_job;
+    String m_blocktemplate;
     State m_state           = IdleState;
     std::shared_ptr<IHttpListener> m_httpListener;
     uint64_t m_retryPause   = 5000;

--- a/src/config.json
+++ b/src/config.json
@@ -74,7 +74,8 @@
             "tls-fingerprint": null,
             "daemon": false,
             "socks5": null,
-            "self-select": null
+            "self-select": null,
+            "submit-to-origin": false
         }
     ],
     "print-time": 60,

--- a/src/core/config/Config_default.h
+++ b/src/core/config/Config_default.h
@@ -106,7 +106,8 @@ R"===(
             "tls": false,
             "tls-fingerprint": null,
             "daemon": false,
-            "self-select": null
+            "self-select": null,
+            "submit-to-origin": false
         }
     ],
     "print-time": 60,

--- a/src/core/config/Config_platform.h
+++ b/src/core/config/Config_platform.h
@@ -57,6 +57,7 @@ static const option options[] = {
     { "daemon",                0, nullptr, IConfig::DaemonKey             },
     { "daemon-poll-interval",  1, nullptr, IConfig::DaemonPollKey         },
     { "self-select",           1, nullptr, IConfig::SelfSelectKey         },
+    { "submit-to-origin",      0, nullptr, IConfig::SubmitToOriginKey     },
 #   endif
     { "av",                    1, nullptr, IConfig::AVKey                 },
     { "background",            0, nullptr, IConfig::BackgroundKey         },

--- a/src/core/config/usage.h
+++ b/src/core/config/usage.h
@@ -64,6 +64,7 @@ static inline const std::string &usage()
     u += "      --daemon                  use daemon RPC instead of pool for solo mining\n";
     u += "      --daemon-poll-interval=N  daemon poll interval in milliseconds (default: 1000)\n";
     u += "      --self-select=URL         self-select block templates from URL\n";
+    u += "      --submit-to-origin        also submit solution back to self-select URL\n";
 #   endif
 
     u += "  -r, --retries=N               number of times to retry before switch to backup server (default: 5)\n";


### PR DESCRIPTION
Add `submit-to-origin` config option With `self-select` mode enabled, this config option will let the `SelfSelectClient` submit the solution to both the daemon where it got the template from as well as to the connected pool.